### PR TITLE
Try not to decrypt "application/pgp-keys" attachments (.asc)

### DIFF
--- a/lib/RT/Crypt/GnuPG.pm
+++ b/lib/RT/Crypt/GnuPG.pm
@@ -841,6 +841,7 @@ sub FindScatteredParts {
 
         my $fname = $part->head->recommended_filename || '';
         next unless $fname =~ /\.${RE_FILE_EXTENSIONS}$/;
+        next if $type eq 'application/pgp-keys';
 
         $RT::Logger->debug("Found encrypted attachment '$fname'");
 


### PR DESCRIPTION
Public keys attached with .asc extension (default many mail clients, for example Thunderbird+Enigmail) were wrongly detected as attachments with inline encryption.
This checks the Content-Type: header for application/pgp-keys and omits the decryption.
